### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ class.sources = plts~.cpp
 # all extra files to be included in binary distribution of the library
 datafiles = plts~-help.pd README.md
 
-cflags = -DTEST -Wno-unused-local-typedefs -I./
+cflags = -DTEST -Wno-unused-local-typedefs -I.
 
 # include Makefile.pdlibbuilder from submodule directory 'pd-lib-builder'
 include Makefile.pdlibbuilder


### PR DESCRIPTION
must be "-I." instead of "-I./", otherwise the header files are not found (at least when building with Msys2 on Windows)

fixes https://github.com/jnonis/pd-plaits/issues/3