### PR TITLE
fix chord engine crash

### DIFF
--- a/plaits/dsp/engine/chord_engine.cc
+++ b/plaits/dsp/engine/chord_engine.cc
@@ -60,13 +60,13 @@ void ChordEngine::Init(BufferAllocator* allocator) {
   morph_lp_ = 0.0f;
   timbre_lp_ = 0.0f;
   
-  ratios_ = allocator->Allocate<float>(kChordNumChords * kChordNumVoices);
+  ratios_ = allocator->Allocate<float>(kChordNumChords * kChordNumNotes);
 }
 
 void ChordEngine::Reset() {
   for (int i = 0; i < kChordNumChords; ++i) {
-    for (int j = 0; j < kChordNumVoices; ++j) {
-      ratios_[i * kChordNumVoices + j] = SemitonesToRatio(chords[i][j]);
+    for (int j = 0; j < kChordNumNotes; ++j) {
+      ratios_[i * kChordNumNotes + j] = SemitonesToRatio(chords[i][j]);
     }
   }
 }


### PR DESCRIPTION
we were looping over the number of voices (5) instead of the number of of notes (4) so this was out of bounds array access

fun details:
```
==20044==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55555c22b370 at pc 0x555557700218 bp 0x7fffd9e91850 sp 0x7fffd9e91840
READ of size 4 at 0x55555c22b370 thread T9
    #0 0x555557700217 in plaits::ChordEngine::Reset() /home/void/plugdata/Libraries/pd-else/Code_source/Compiled/signal/plaits~/plaits/dsp/engine/chord_engine.cc:69
    #1 0x5555576b1aed in plaits::Voice::Render(plaits::Patch const&, plaits::Modulations const&, plaits::Voice::Frame*, unsigned long) /home/void/plugdata/Libraries/pd-else/Code_source/Compiled/signal/plaits~/plaits/dsp/voice.cc:154
    #2 0x5555575b4345 in plts_perform /home/void/plugdata/Libraries/pd-else/Code_source/Compiled/signal/plaits~/plaits~.cpp:247
    #3 0x555557384bd4 in dsp_tick /home/void/plugdata/Libraries/pure-data/src/d_ugen.c:393
    #4 0x55555730c28e in sched_tick /home/void/plugdata/Libraries/pure-data/src/m_sched.c:261
    #5 0x5555573417cb in libpd_process_raw /home/void/plugdata/Libraries/pure-data/src/z_libpd.c:233
    #6 0x555556bb5c53 in PluginProcessor::process(juce::dsp::AudioBlock<float>, juce::MidiBuffer&) /home/void/plugdata/Source/PluginProcessor.cpp:669
    #7 0x555556bb999a in PluginProcessor::processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) /home/void/plugdata/Source/PluginProcessor.cpp:508
    #8 0x555555c1aca2 in juce::AudioProcessorPlayer::audioDeviceIOCallbackWithContext(float const* const*, int, float* const*, int, int, juce::AudioIODeviceCallbackContext const&) /home/void/plugdata/Libraries/JUCE/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.cpp:328
    #9 0x555555b8e24f in StandalonePluginHolder::CallbackMaxSizeEnforcer::audioDeviceIOCallbackWithContext(float const* const*, int, float* const*, int, int, juce::AudioIODeviceCallbackContext const&) /home/void/plugdata/Source/Standalone/PlugDataWindow.h:340
    #10 0x555556a01162 in juce::AudioDeviceManager::audioDeviceIOCallbackInt(float const* const*, int, float* const*, int, int, juce::AudioIODeviceCallbackContext const&) /home/void/plugdata/Libraries/JUCE/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp:1002
    #11 0x5555569e8349 in run /home/void/plugdata/Libraries/JUCE/modules/juce_audio_devices/native/juce_linux_ALSA.cpp:714
    #12 0x5555566ed236 in juce::Thread::threadEntryPoint() /home/void/plugdata/Libraries/JUCE/modules/juce_core/threads/juce_Thread.cpp:98
    #13 0x5555566ed418 in juce::juce_threadEntryPoint(void*) /home/void/plugdata/Libraries/JUCE/modules/juce_core/threads/juce_Thread.cpp:120
    #14 0x5555566ed418 in operator() /home/void/plugdata/Libraries/JUCE/modules/juce_core/native/juce_linux_Threads.cpp:40
    #15 0x5555566ed418 in _FUN /home/void/plugdata/Libraries/JUCE/modules/juce_core/native/juce_linux_Threads.cpp:43
    #16 0x7ffff6fbeaf9 in start_thread nptl/pthread_create.c:442
    #17 0x7ffff703f73b in clone3 (/usr/lib/libc.so.6+0x10a73b)

0x55555c22b370 is located 0 bytes to the right of global variable 'chords' defined in '/home/void/plugdata/Libraries/pd-else/Code_source/Compiled/signal/plaits~/plaits/dsp/engine/chord_engine.cc:40:13' (0x55555c22b2c0) of size 176
SUMMARY: AddressSanitizer: global-buffer-overflow /home/void/plugdata/Libraries/pd-else/Code_source/Compiled/signal/plaits~/plaits/dsp/engine/chord_engine.cc:69 in plaits::ChordEngine::Reset()
Shadow bytes around the buggy address:
  0x0aab2b83d610: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d620: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d630: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d640: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0aab2b83d650: 00 00 04 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
=>0x0aab2b83d660: 00 00 00 00 00 00 00 00 00 00 00 00 00 00[f9]f9
  0x0aab2b83d670: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d690: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aab2b83d6a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9
  0x0aab2b83d6b0: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T9 created by T0 here:
    #0 0x7ffff784a545 in __interceptor_pthread_create (/usr/lib64/libasan.so.8+0x4a545)
    #1 0x55555663f637 in makeThreadHandle /home/void/plugdata/Libraries/JUCE/modules/juce_core/native/juce_posix_SharedCode.h:966
    #2 0x55555663f637 in juce::Thread::createNativeThread(juce::Thread::Priority) /home/void/plugdata/Libraries/JUCE/modules/juce_core/native/juce_linux_Threads.cpp:36

==20044==ABORTING
```